### PR TITLE
Fix yarn typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## installation
 ```
-yarn global lagom #much faster
+yarn global add lagom # much faster
 ```
 or
 ```


### PR DESCRIPTION
Yarn says `yarn global lagom` isn't right, but `yarn global add lagom` does work.