### PR TITLE
Support Printing Presentations

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -23,7 +23,7 @@ const onKey = event => {
 
   if      (keyCode == 37) previousSlide()
   else if (keyCode == 39) nextSlide()
-  else if (keyCode == 80) openPresentationWindow()
+  else if (keyCode == 80 && !(event.metaKey || event.ctrlKey)) openPresentationWindow()
 }
 
 const initLagom = () => {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,3 +14,19 @@
 @import "elements/iframe";
 
 @import "vendor/highlight";
+
+@media print {
+  body {
+    height: auto;
+    overflow: scroll;
+  }
+
+  section {
+    opacity: 1;
+    height: 100vh;
+  }
+
+  span[id=lagom-mousepointer] {
+    display: none;
+  }
+}


### PR DESCRIPTION
Hi

I've added a basic print stylesheet so it's possible to print a presentation, which I needed to convert a presentation to PDF.

I also added a check to the key press event handler so it doesn't open presentation mode when <kbd>cmd</kbd> or <kbd>ctrl</kbd> is pressed &mdash; in Chrome this stopped the print menu from opening, so now it only opens presentation mode when <kbd>cmd</kbd> & <kbd>ctrl</kbd> aren't pressed.

Thanks for the awesome library; it works way better than anything else I've used!