### PR TITLE
Allow using HTML in code blocks

### DIFF
--- a/src/scripts/modules/codeBlocks.js
+++ b/src/scripts/modules/codeBlocks.js
@@ -4,8 +4,10 @@ export const renderCodeBlocks = () => {
   const codes = document.getElementsByTagName('code')
 
   Array.prototype.forEach.call(codes, (code) => {
-    code.innerHTML = code.innerHTML.replace(/</g, '&lt;')
+    if (!code.classList.contains('noescape')) {
+      code.innerHTML = code.innerHTML.replace(/</g, '&lt;')
+    }
+
     hljs.highlightBlock(code)
   })
-
 }


### PR DESCRIPTION
Using a `noescape` class (to mimic `nohighlight` from HLJS) you can specify that you don't want HTML tags in code blocks to be escaped.

This lets you add custom markup to a code block, which currently doesn't seem possible.